### PR TITLE
BREAKING CHANGE: change data directory, change data read model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 node_modules
 package-lock.json
-bikeshed-data/
-xref-data.json
+data

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 .editorconfig
 .gitattributes
-bikeshed-data
+.github
 node_modules
 package-lock.json
-xref-data.json
+data

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+const path = require("path");
+const { readFileSync } = require("fs");
+
 const IDL_TYPES = new Set([
   "_IDL_",
   "attribute",
@@ -23,7 +26,10 @@ const defaultOptions = {
   types: [], // any
 };
 
-function createResponseBody({ options: opts = {}, keys = [] }, data) {
+const cache = new Map();
+
+function xrefSearch(keys = [], opts = {}) {
+  const data = getData('xref', 'xref.json');
   const options = { ...defaultOptions, ...opts };
   const response = Object.create(null);
 
@@ -103,7 +109,22 @@ function pickFields(item, fields) {
 
 function getUnique(termData) {
   const unique = new Set(termData.map(JSON.stringify));
-  return [...unique].map(JSON.parse);
+  return [...unique].map(strData => JSON.parse(strData));
 }
 
-module.exports = createResponseBody;
+function getData(key, filename) {
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+
+  const dataFile = path.resolve(__dirname, `../../data/xref/${filename}`);
+  const text = readFileSync(dataFile, "utf8");
+  const data = JSON.parse(text);
+  cache.set(key, data);
+  return data;
+}
+
+module.exports = {
+  cache,
+  xrefSearch,
+};

--- a/index.js
+++ b/index.js
@@ -26,9 +26,34 @@ const defaultOptions = {
   types: [], // any
 };
 
+/**
+ * @typedef {{
+    [term: string]: {
+      "type": string;
+      "spec": string;
+      "shortname": string;
+      status: "snapshot" | "current";
+      uri: string;
+      normative: boolean;
+      for?: string[];
+    }[]
+  }} XrefData
+ * @type {Map<"xref", XrefData>}
+ */
 const cache = new Map();
 
+/**
+ * @typedef {{
+    term: string;
+    types?: string[];
+    specs?: string[];
+    for?: string;
+  }} XrefRequestEntry
+ * @param {XrefRequestEntry[]} keys
+ * @param {typeof<defaultOptions>} opts
+ */
 function xrefSearch(keys = [], opts = {}) {
+  /** @type {XrefData} */
   const data = getData('xref', 'xref.json');
   const options = { ...defaultOptions, ...opts };
   const response = Object.create(null);

--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ const defaultOptions = {
  */
 const cache = new Map();
 
+// load initial data and cache it
+getData('xref', 'xref.json');
+
 /**
  * @typedef {{
     term: string;

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   "author": "Sid Vishnoi <sidvishnoi8@gmail.com>",
   "main": "index.js",
   "bin": {
-    "fetch-bs-data": "./scraper/scrape.sh",
-    "convert-bs-data": "./scraper/scraper.js"
+    "fetch-bs-data": "./scraper/get-data.sh",
+    "convert-bs-data": "./scraper/process-data.js"
   },
   "scripts": {
-    "fetch": "./scraper/scrape.sh",
-    "convert": "./scraper/scraper.js"
+    "fetch": "./scraper/get-data.sh",
+    "convert": "./scraper/process-data.js"
   },
   "dependencies": {
     "compact-prefix-tree": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",

--- a/scraper/get-data.sh
+++ b/scraper/get-data.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+mkdir -p data/xref
+cd data
 if [ -d "bikeshed-data" ]; then
   cd bikeshed-data
   git pull origin master

--- a/scraper/process-data.js
+++ b/scraper/process-data.js
@@ -11,9 +11,9 @@ const { CompactPrefixTree: Trie } = require("compact-prefix-tree");
 const readFileAsync = promisify(readFile);
 const writeFileAsync = promisify(writeFile);
 
-const SPECS_JSON = path.resolve("./bikeshed-data/data/specs.json");
-const INPUT_DIR = path.resolve("./bikeshed-data/data/anchors/");
-const OUT_FILE = path.resolve("./xref-data.json");
+const SPECS_JSON = path.resolve("./data/bikeshed-data/data/specs.json");
+const INPUT_DIR = path.resolve("./data/bikeshed-data/data/anchors/");
+const OUT_FILE = path.resolve("./data/xref/xref.json");
 
 const SUPPORTED_TYPES = new Set([
   "attribute",


### PR DESCRIPTION
- Moved raw data to `/data/bikeshed-data/`
- Moved processed data to `/data/xref/`
- Changed function signature: It no longer accepts data
- Added a function `getData` which reads data files, or returns from cache if available
- Renamed scraper scripts
- Added jsDoc annotations
- Bumped version to 3.0.0