### PR TITLE
BREAKING CHANGE: change response format

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,34 @@
+export interface DataEntry {
+  type: string;
+  spec: string;
+  shortname: string;
+  status: 'snapshot' | 'current';
+  uri: string;
+  normative: boolean;
+  for?: string[];
+}
+
+export interface Database {
+  [term: string]: DataEntry[];
+}
+
+export interface HashCacheEntry {
+  time: number;
+  value: DataEntry[];
+}
+
+export type Cache = Map<'xref', Database> &
+  Map<'cache', Map<string, HashCacheEntry>>;
+
+export interface RequestEntry {
+  term: string;
+  hash: string;
+  types?: string[];
+  specs?: string[];
+  for?: string;
+}
+
+export interface Response {
+  result: DataEntry[];
+  query?: RequestEntry[];
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",


### PR DESCRIPTION
Public API changes:

- added optional but recommended `hash` field in `RequestEntry`
- xref response data is moved to `Response.result`
- added an option to return request query in response (`options.query`)

We return a result entry corresponding to each query key. This enables caching on server and reduces complexity. Did some refactoring of TS types also.