### PR TITLE
BREAKING CHANGE: change response format

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ export interface DataEntry {
   type: string;
   spec: string;
   shortname: string;
-  status: 'snapshot' | 'current';
+  status: "snapshot" | "current";
   uri: string;
   normative: boolean;
   for?: string[];
@@ -35,6 +35,6 @@ export interface RequestEntry {
 }
 
 export interface Response {
-  result: DataEntry[];
+  result: [string, DataEntry[]][];
   query?: RequestEntry[];
 }

--- a/index.js
+++ b/index.js
@@ -37,12 +37,11 @@ const defaultOptions = {
 
 /** @param {RequestEntry[]} keys */
 function xrefSearch(keys = [], opts = {}) {
-  /** @type {Database} */
   const data = cache.get("xref");
   const options = { ...defaultOptions, ...opts };
 
   /** @type {Response} */
-  const response = { result: Object.create(null) };
+  const response = { result: [] };
   if (options.query) response.query = [];
 
   const requestCache = cache.get("request");
@@ -55,7 +54,7 @@ function xrefSearch(keys = [], opts = {}) {
     }
     const prefereredData = filterBySpecType(termData, options.spec_type);
     const result = prefereredData.map(item => pickFields(item, options.fields));
-    response.result[id] = result;
+    response.result.push([id, result]);
     if (options.query) {
       response.query.push(entry.id ? entry : { ...entry, id });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",


### PR DESCRIPTION
``` js
const request = { keys: [{id: id1}, {id: id1}, {id: id2}] }
```

Earlier:
``` js
const response = { result: {
 id1: data[],
 id2: data[],
}}
```
Now:
``` js
const response = { result: [
  [id1, data[]],
  [id1, data[]],
  [id2, data[]],
]}
```
New response can be made to a Map/Object by using `new Map(response.result)` or `Object.fromEntries(response.result)`

Closes https://github.com/sidvishnoi/respec-xref-route/issues/27