### PR TITLE
Add a request-response cache

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,24 +8,6 @@ export interface DataEntry {
   for?: string[];
 }
 
-export interface Database {
-  [term: string]: DataEntry[];
-}
-
-export interface HashCacheEntry {
-  time: number;
-  value: DataEntry[];
-}
-
-export type RequestCache = Map<string, HashCacheEntry>;
-
-export declare class Cache extends Map {
-  get<K extends string>(
-    key: K,
-  ): K extends "request" ? RequestCache : K extends "xref" ? Database : any;
-  reset(): void;
-}
-
 export interface RequestEntry {
   term: string;
   id?: string;
@@ -37,4 +19,15 @@ export interface RequestEntry {
 export interface Response {
   result: [string, DataEntry[]][];
   query?: RequestEntry[];
+}
+
+export interface CacheEntry {
+  query: Map<string, { time: number; value: DataEntry[] }>;
+  by_term: { [term: string]: DataEntry[] };
+  response: Map<string, { time: number; value: Response }>;
+}
+
+export declare class Cache extends Map {
+  get<K extends keyof CacheEntry>(key: K): CacheEntry[K];
+  reset(): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,4 +51,5 @@ export interface CacheEntry {
 export declare class Cache extends Map {
   get<K extends keyof CacheEntry>(key: K): CacheEntry[K];
   reset(): void;
+  autoCleanCaches(): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,27 @@ export interface RequestEntry {
   for?: string;
 }
 
+type Field = "for" | "normative" | "shortname" | "spec"| "type" | "uri";
+type Type =
+  | "attribute"
+  | "dfn"
+  | "dict-member"
+  | "dictionary"
+  | "element"
+  | "enum-value"
+  | "enum"
+  | "event"
+  | "interface"
+  | "method"
+  | "typedef";
+export interface Options {
+  fields: Field[];
+  spec_type: ["draft", "official"];
+  types: Type[];
+  query?: boolean;
+  id?: string;
+}
+
 export interface Response {
   result: [string, DataEntry[]][];
   query?: RequestEntry[];

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@
  * @typedef {import('.').Options} Options
  */
 const crypto = require("crypto");
-const { cache } = require("./utils");
+const {
+  cache,
+  QUERY_CACHE_DURATION,
+  RESPONSE_CACHE_DURATION,
+} = require("./utils");
 
 const IDL_TYPES = new Set([
   "_IDL_",
@@ -21,9 +25,6 @@ const IDL_TYPES = new Set([
 ]);
 
 const CONCEPT_TYPES = new Set(["_CONCEPT_", "dfn", "element", "event"]);
-
-const QUERY_CACHE_DURATION = 3 * 24 * 60 * 60 * 1000; // 3 days
-const RESPONSE_CACHE_DURATION = 4 * 60 * 60 * 1000; // 4 hours
 
 const specStatusAlias = new Map([
   ["draft", "current"],

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  * @typedef {import('.').RequestEntry} RequestEntry
  * @typedef {import('.').CacheEntry} CacheEntry
  * @typedef {import('.').Response} Response
+ * @typedef {import('.').Options} Options
  */
 const crypto = require("crypto");
 const { cache } = require("./utils");
@@ -29,6 +30,7 @@ const specStatusAlias = new Map([
   ["official", "snapshot"],
 ]);
 
+/** @type {Options} */
 const defaultOptions = {
   fields: ["shortname", "type", "for", "normative", "uri"],
   spec_type: ["draft", "official"],

--- a/utils.js
+++ b/utils.js
@@ -6,11 +6,14 @@ class Cache extends Map {
     super();
     this.reset();
   }
+
   reset() {
-    // placeholder for id based cache
-    this.set("request", new Map());
+    // placeholder for query (key) id based cache
+    this.set("query", new Map());
+    // placeholder for "request.options.id" based cache
+    this.set("response", new Map());
     // load initial data and cache it
-    this.set("xref", this.readJson("xref.json"));
+    this.set("by_term", this.readJson("xref.json"));
   }
 
   readJson(filename) {


### PR DESCRIPTION
Given a unique id in `options.id`, we can return a response straight away from cache.

How we can generate that ID from ReSpec? `respecConfig.shortName + "-" + respecConfig.publishISODate` should be enough. Whenever there is a new update on spec, `publishISODate` changes, and we use a new version instead of cached result.

Would like to know your view on cache duration. And please review commit by commit.