### PR TITLE
fix(utils): add missing extended-attribute type

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -53,6 +53,7 @@ const IDL_TYPES = new Set([
   "enum-value",
   "enum",
   "exception",
+  "extended-attribute",
   "interface",
   "method",
   "typedef",


### PR DESCRIPTION
Missing type for things like `[Constructor]`