### PR TITLE
fix(search/filterBySpecType): prefer only if same spec already in results

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,14 +208,26 @@ function filter(item, entry, options) {
   return isAcceptable;
 }
 
+/**
+ * @param {DataEntry[]} data
+ * @param {DataEntry['status'][]} specTypes
+ */
 function filterBySpecType(data, specTypes) {
   if (!specTypes.length) return data;
 
-  const prefereredType = specStatusAlias.get(specTypes[0]) || specTypes[0];
-  const filteredData = data.filter(item => item.status === prefereredType);
+  const preferredType = specStatusAlias.get(specTypes[0]) || specTypes[0];
+  const preferredData = [];
+  for (const item of data) {
+    if (
+      item.status === preferredType ||
+      !preferredData.find(it => item.spec === it.spec && item.type === it.type)
+    ) {
+      preferredData.push(item);
+    }
+  }
 
-  const hasPrefereredData = specTypes.length === 2 && filteredData.length;
-  return specTypes.length === 1 || hasPrefereredData ? filteredData : data;
+  const hasPreferredData = specTypes.length === 2 && preferredData.length;
+  return specTypes.length === 1 || hasPreferredData ? preferredData : data;
 }
 
 function pickFields(item, fields) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",


### PR DESCRIPTION
Fixes the case when:
``` js
data = [
  {
    type: "dfn",
    spec: "fileapi-1",
    status: "current",
    uri: "#blob-url-entry-object",
  },
  {
    type: "element",
    spec: "html",
    status: "snapshot",
    uri: "iframe-embed-object.html#the-object-element",
  }
]
```

returned only the `fileapi` result as only it had the preferred status "current".