### PR TITLE
fix(search/filterBySpecType): handle case when non-preferred comes prior

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,9 @@ function filterBySpecType(data, specTypes) {
 
   const preferredType = specStatusAlias.get(specTypes[0]) || specTypes[0];
   const preferredData = [];
+  data.sort((a, b) =>
+    a.status === preferredType ? -1 : b.status === preferredType ? 1 : 0,
+  );
   for (const item of data) {
     if (
       item.status === preferredType ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",


### PR DESCRIPTION
Missed the following case in which snapshot (non-preferred) comes before current (preferred):
``` js
      {
        type: "interface",
        spec: "webauthn-1",
        status: "snapshot",
        uri: "#publickeycredential",
      },
      {
        type: "interface",
        spec: "webauthn-1",
        status: "current",
        uri: "#publickeycredential",
      },
```
and ended up returning both