### PR TITLE
 feat(options): add .all to skip explicit forContext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ export interface Options {
   types: Type[];
   query?: boolean;
   id?: string;
+  all?: boolean;
 }
 
 export interface Response {

--- a/index.js
+++ b/index.js
@@ -197,7 +197,8 @@ function filter(item, entry, options) {
     }
   }
 
-  if (isAcceptable) {
+  // if `options.all` is true and `forContext` isn't provided, we skip the this filter
+  if (isAcceptable && (options.all ? typeof forContext === "string" : true)) {
     if (!forContext) {
       isAcceptable = !item.for;
     } else {

--- a/index.js
+++ b/index.js
@@ -197,8 +197,8 @@ function filter(item, entry, options) {
     }
   }
 
-  if (isAcceptable && typeof forContext === "string") {
-    if (forContext === "") {
+  if (isAcceptable) {
+    if (!forContext) {
       isAcceptable = !item.for;
     } else {
       isAcceptable = item.for && item.for.includes(forContext);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",


### PR DESCRIPTION
``` js
let request = { term: "fully active" };

// result without options.all
[] 

// result with options.all set to true, the explicit forContext check is bypassed
[
  {
    shortname: 'html',
    type: 'dfn',
    for: [ 'Document' ],
    normative: true,
    uri: 'browsers.html#fully-active'
  }
]
```

Useful in xref UI