### PR TITLE
fix(search): caching regression causing ambiguities

### DIFF
--- a/search.ts
+++ b/search.ts
@@ -122,7 +122,7 @@ function getTermData(
 
   const result = termData.filter(item => filter(item, query, options));
 
-  cache.set(id, { time: Date.now(), value: termData });
+  cache.set(id, { time: Date.now(), value: result });
   return result;
 }
 


### PR DESCRIPTION
The first request returned filtered result. But cached unfiltered results. So, all further requests had "ambiguous results" 🤦‍♂ 