### PR TITLE
fix(search): id-less queries were cached wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respec-xref-route",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Keyword based search API for CSSWG's Shepherd data, used in ReSpec.",
   "keywords": [
     "csswg",

--- a/search.ts
+++ b/search.ts
@@ -75,13 +75,15 @@ export function search(queries: Query[] = [], opts: Partial<Options> = {}) {
       query.specs = [query.specs]; // for backward compatibility
     }
 
-    const { id = objectHash(query) } = query;
+    if (!query.id) {
+      query.id = objectHash(query);
+    }
     const termData = getTermData(query, queryCache, data, options);
     const prefereredData = filterBySpecType(termData, options.spec_type);
     const result = prefereredData.map(item => pickFields(item, options.fields));
-    response.result.push([id, result]);
+    response.result.push([query.id, result]);
     if (options.query) {
-      response.query!.push(query.id ? query : { ...query, id });
+      response.query!.push(query);
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/sidvishnoi/respec-xref-route/issues/48