### PR TITLE
enhancement(search): prefer latest version of spec

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -155,10 +155,13 @@ describe('filter@specs', () => {
     expect(search({ term, specs: [['css-cascade-4']] }, options)).toEqual([
       { spec: 'css-cascade-4', uri: '#inherited-value' },
     ]);
+  });
 
+  it('prefers latest version of same spec', () => {
+    const term = 'inherited value';
+    const options = { fields: ['spec', 'uri'] };
     expect(search({ term, specs: [['css-cascade']] }, options)).toEqual([
       { spec: 'css-cascade-4', uri: '#inherited-value' },
-      { spec: 'css-cascade-3', uri: '#inherited-value' },
     ]);
   });
 


### PR DESCRIPTION
Example: term: used value
specs: [css-cascade-4] => return css-cascade-4
specs: [css-cascade-3] => return css-cascade-3
specs: [css-cascade] => return css-cascade-4 (instead of returning [css-cascade-4, css-cascade-3])