### PR TITLE
feat: support css types

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -24,11 +24,22 @@ export const IDL_TYPES = new Set([
 // https://github.com/sidvishnoi/respec-xref-route/issues/57
 export const CONCEPT_TYPES = new Set(['_CONCEPT_', 'dfn', 'event', 'element']);
 export const MARKUP_TYPES = new Set(['element', 'element-attr']);
+export const CSS_TYPES_INPUT = new Set([
+  'property',
+  'descriptor',
+  'value',
+  'type',
+  'at-rule',
+  'function',
+  'selector',
+]);
+export const CSS_TYPES = new Set([...CSS_TYPES_INPUT].map(t => `css-${t}`));
 
 export const SUPPORTED_TYPES = new Set([
   ...IDL_TYPES,
   ...CONCEPT_TYPES,
   ...MARKUP_TYPES,
+  ...CSS_TYPES,
 ]);
 
 export const QUERY_CACHE_DURATION = 3 * 24 * 60 * 60 * 1000; // 3 days

--- a/scraper.ts
+++ b/scraper.ts
@@ -7,7 +7,7 @@ import { promises as fs, existsSync } from 'fs';
 import { resolve as resolvePath, join as joinPath } from 'path';
 import { spawn } from 'child_process';
 import Trie from 'compact-prefix-tree/cjs';
-import { SUPPORTED_TYPES, DATA_DIR } from './constants';
+import { SUPPORTED_TYPES, DATA_DIR, CSS_TYPES_INPUT } from './constants';
 import { uniq } from './utils';
 import { Store } from './store';
 
@@ -178,11 +178,11 @@ function parseAnchorSection(section: string) {
   ] = section.split('\n');
 
   const dataFor = forContext.filter(Boolean);
-
+  const normalizedType = CSS_TYPES_INPUT.has(type) ? `css-${type}` : type;
   return {
-    term: normalizeTerm(term, type),
+    term: normalizeTerm(term, normalizedType),
     isExported: isExported === '1',
-    type,
+    type: normalizedType,
     spec,
     shortname,
     status,


### PR DESCRIPTION
This will allow ReSpec to link to CSS types as:
``` html
<!-- links to <color> at https://www.w3.org/TR/css-color-4/#typedef-color -->
<a data-cite="css-color-4" data-xref-type="css-type">&lt;color&gt;</a>
```

ReSpec may use a micro-syntax to simplify this.