### PR TITLE
chore(ci/changelog): automate changelog generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,21 @@
+name: Changelog
+on:
+  workflow_dispatch: {}
+
+jobs:
+  changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+      - run: gem install github_changelog_generator
+      - run: github_changelog_generator -u w3c -p respec --no-unreleased
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: peter-evans/create-pull-request@v2
+        with:
+          commit-message: 'chore(CHANGELOG): regenerate'
+          title: 'chore(CHANGELOG): regenerate'
+          draft: true # TODO: remove me
+          branch: regenerate-changelog


### PR DESCRIPTION
Experimenting for https://github.com/w3c/respec/pull/3009, as changelog generation is really slow there (15min). Will merge this, and see if it works fine. Might remove later.