### PR TITLE
BREAKING CHANGE: use definitions data from w3c/webref

### DIFF
--- a/@types/compact-prefix-tree.d.ts
+++ b/@types/compact-prefix-tree.d.ts
@@ -1,4 +1,0 @@
-declare module 'compact-prefix-tree/cjs' {
-  export { default } from 'compact-prefix-tree';
-  export * from 'compact-prefix-tree';
-}

--- a/@types/webref.d.ts
+++ b/@types/webref.d.ts
@@ -1,0 +1,40 @@
+declare module 'webref' {
+  /** A file in `(ed|tr)/dfns/{file}.json` */
+  export interface DfnsJSON {
+    series: string;
+    spec: string;
+    url: string;
+    dfns: Definition[];
+  }
+
+  export interface Definition {
+    id: string;
+    href: string;
+    linkingText: string[];
+    localLinkingText: string[];
+    type: string;
+    for: string[];
+    access: 'private' | 'public';
+    informative: boolean;
+    heading: Record<string, string>;
+    definedIn: string;
+  }
+
+  interface SpecVersion {
+    url: string;
+  }
+
+  /** A file in (ed|tr)/index.json */
+  export interface SpecsJSON {
+    url: string;
+    shortname: string;
+    nightly: SpecVersion;
+    release?: SpecVersion;
+    series: {
+      shortname: string;
+      currentSpecification: string;
+    };
+    title: string;
+    dfns?: string;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,11 +1248,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "compact-prefix-tree": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/compact-prefix-tree/-/compact-prefix-tree-2.0.2.tgz",
-      "integrity": "sha512-ShiUvZ+1hHzjTZxp6+3r/uzQwfYBQbhkBHBHaewZTpHSE9PcrpacRfb0WVhYKIXVKn7J+IBjWttujVlruSFWiw=="
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "test": "jest",
     "test:nobuild": "jest"
   },
-  "dependencies": {
-    "compact-prefix-tree": "^2.0.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^14.14.10",
     "jest": "^26.6.3",

--- a/scraper.ts
+++ b/scraper.ts
@@ -50,7 +50,7 @@ export async function main(options: Partial<Options> = {}) {
 
   const dataByTerm: DataByTerm = Object.create(null);
   const dataBySpec: DataBySpec = Object.create(null);
-  log(`Processing ${dfnSources.size} files...`);
+  log(`Processing ${dfnSources.length} files...`);
   for (const source of dfnSources) {
     try {
       const terms = parseData(source);
@@ -178,7 +178,7 @@ async function getSpecsData() {
 
   const specMap: Store['specmap'] = Object.create(null);
   const specUrls = new Set<string>();
-  const dfnSources = new Set<DfnsJSON>();
+  const dfnSources: DfnsJSON[] = [];
 
   for (const entry of data) {
     specUrls.add(entry.nightly.url);
@@ -186,7 +186,7 @@ async function getSpecsData() {
     if (entry.dfns) {
       const dfnsData = await readJSON(joinPath(INPUT_DIR_BASE, entry.dfns));
       const dfns: InputDfn[] = dfnsData.dfns;
-      dfnSources.add({
+      dfnSources.push({
         series: entry.series.shortname,
         spec: entry.shortname,
         url: entry.nightly.url,

--- a/scraper.ts
+++ b/scraper.ts
@@ -11,7 +11,7 @@ import { uniq } from './utils';
 import { Store } from './store';
 import { Definition as InputDfn, DfnsJSON, SpecsJSON } from 'webref';
 
-const { readdir, readFile, writeFile } = fs;
+const { readFile, writeFile } = fs;
 
 const INPUT_DIR_BASE = joinPath(DATA_DIR, 'webref', 'ed');
 const SPECS_JSON = resolvePath(INPUT_DIR_BASE, './index.json');
@@ -51,7 +51,7 @@ export async function main(options: Partial<Options> = {}) {
   const dataByTerm: DataByTerm = Object.create(null);
   const dataBySpec: DataBySpec = Object.create(null);
   log(`Processing ${dfnSources.size} files...`);
-  for (let source of dfnSources) {
+  for (const source of dfnSources) {
     try {
       const terms = parseData(source);
       updateDataByTerm(terms, dataByTerm);
@@ -124,14 +124,16 @@ function mapDefinition(
   term: string,
   spec: Record<'spec' | 'shortname' | 'url', string>,
 ) {
-  const normalizedType = CSS_TYPES_INPUT.has(dfn.type) ? `css-${dfn.type}` : dfn.type;
+  const normalizedType = CSS_TYPES_INPUT.has(dfn.type)
+    ? `css-${dfn.type}`
+    : dfn.type;
   return {
     term: normalizeTerm(term, normalizedType),
     isExported: dfn.access === 'public',
     type: normalizedType,
     spec: spec.spec,
     shortname: spec.shortname,
-    status: "current",
+    status: 'current',
     uri: dfn.href.replace(spec.url, ''), // This is full URL to term here
     normative: !dfn.informative,
     for: dfn.for.length > 0 ? dfn.for : undefined,
@@ -188,7 +190,7 @@ async function getSpecsData() {
         series: entry.series.shortname,
         spec: entry.shortname,
         url: entry.nightly.url,
-        dfns
+        dfns,
       });
     }
 

--- a/scraper.ts
+++ b/scraper.ts
@@ -25,6 +25,7 @@ type ParsedDataEntry = ReturnType<typeof parseData>[0];
 interface DfnSource {
   series: string;
   spec: string;
+  url: string;
   dfns: Array<WebrefDfn>;
 }
 
@@ -137,7 +138,7 @@ function parseData(source: DfnSource, errorURIs: string[]) {
   const termData = [];
   for (const dfn of dfns) {
     for (const term of dfn.linkingText) {
-      const mapped = mapDefinition(dfn, term, source.spec, source.series);
+      const mapped = mapDefinition(dfn, term, source.spec, source.series, source.url);
       termData.push(mapped);
     }
   }
@@ -149,7 +150,7 @@ function parseData(source: DfnSource, errorURIs: string[]) {
   return uniq(filtered);
 }
 
-function mapDefinition(dfn: WebrefDfn, term: string, spec: string, series: string) {
+function mapDefinition(dfn: WebrefDfn, term: string, spec: string, series: string, specurl: string) {
   const normalizedType = CSS_TYPES_INPUT.has(dfn.type) ? `css-${dfn.type}` : dfn.type;
   return {
     term: normalizeTerm(term, normalizedType),
@@ -158,7 +159,7 @@ function mapDefinition(dfn: WebrefDfn, term: string, spec: string, series: strin
     spec,
     shortname: series,
     status: "current",
-    uri: '#' + dfn.id, // This is full URL to term here
+    uri: dfn.href.replace(specurl, ''), // This is full URL to term here
     normative: !dfn.informative,
     for: dfn.for.length > 0 ? dfn.for : undefined,
   };
@@ -229,6 +230,7 @@ async function getSpecsData() {
       dfnSources.add({
         series: entry.series.shortname,
         spec: entry.shortname,
+        url: entry.nightly.url,
         dfns
       });
     }

--- a/scraper.ts
+++ b/scraper.ts
@@ -166,8 +166,8 @@ function normalizeTerm(term: string, type: string) {
 
 async function getSpecsData() {
   log(`Getting spec metadata from ${SPECS_JSON}`);
-  const urlFileContent = await readFile(SPECS_JSON, 'utf8');
-  const data: Array<SpecsJSON> = JSON.parse(urlFileContent).results;
+  const urlFileContent = await readJSON(SPECS_JSON);
+  const data: Array<SpecsJSON> = urlFileContent.results;
 
   const specMap: Store['specmap'] = Object.create(null);
   const specUrls = new Set<string>();
@@ -177,7 +177,8 @@ async function getSpecsData() {
     specUrls.add(entry.nightly.url);
     if (entry.release && entry.release.url) specUrls.add(entry.release.url);
     if (entry.dfns) {
-      const dfns = JSON.parse(await readFile(joinPath(INPUT_DIR_BASE, entry.dfns), 'utf8')).dfns;
+      const dfnsData = await readJSON(joinPath(INPUT_DIR_BASE, entry.dfns));
+      const dfns: InputDfn[] = dfnsData.dfns;
       dfnSources.add({
         series: entry.series.shortname,
         spec: entry.shortname,
@@ -195,6 +196,11 @@ async function getSpecsData() {
 
   const urls = [...specUrls].sort();
   return { urls, specMap, dfnSources };
+}
+
+async function readJSON(filePath: string) {
+  const text = await readFile(filePath, 'utf-8');
+  return JSON.parse(text);
 }
 
 if (require.main === module) {

--- a/scraper.ts
+++ b/scraper.ts
@@ -102,11 +102,12 @@ function updateInputSource() {
  * @param source content of an dfns data file
  */
 function parseData(source: DfnsJSON) {
-  const dfns = source.dfns;
+  const { dfns, spec, series, url } = source;
+  const specMetaData = { spec, shortname: series, url };
   const termData = [];
   for (const dfn of dfns) {
     for (const term of dfn.linkingText) {
-      const mapped = mapDefinition(dfn, term, source.spec, source.series, source.url);
+      const mapped = mapDefinition(dfn, term, specMetaData);
       termData.push(mapped);
     }
   }
@@ -118,16 +119,20 @@ function parseData(source: DfnsJSON) {
   return uniq(filtered);
 }
 
-function mapDefinition(dfn: InputDfn, term: string, spec: string, series: string, specurl: string) {
+function mapDefinition(
+  dfn: InputDfn,
+  term: string,
+  spec: Record<'spec' | 'shortname' | 'url', string>,
+) {
   const normalizedType = CSS_TYPES_INPUT.has(dfn.type) ? `css-${dfn.type}` : dfn.type;
   return {
     term: normalizeTerm(term, normalizedType),
     isExported: dfn.access === 'public',
     type: normalizedType,
-    spec,
-    shortname: series,
+    spec: spec.spec,
+    shortname: spec.shortname,
     status: "current",
-    uri: dfn.href.replace(specurl, ''), // This is full URL to term here
+    uri: dfn.href.replace(spec.url, ''), // This is full URL to term here
     normative: !dfn.informative,
     for: dfn.for.length > 0 ? dfn.for : undefined,
   };

--- a/scraper.ts
+++ b/scraper.ts
@@ -174,7 +174,7 @@ function normalizeTerm(term: string, type: string) {
 async function getSpecsData() {
   log(`Getting spec metadata from ${SPECS_JSON}`);
   const urlFileContent = await readJSON(SPECS_JSON);
-  const data: Array<SpecsJSON> = urlFileContent.results;
+  const data: SpecsJSON[] = urlFileContent.results;
 
   const specMap: Store['specmap'] = Object.create(null);
   const specUrls = new Set<string>();

--- a/scraper.ts
+++ b/scraper.ts
@@ -69,24 +69,16 @@ export async function main(options: Partial<Options> = {}) {
 
   const dataByTerm: DataByTerm = Object.create(null);
   const dataBySpec: DataBySpec = Object.create(null);
-  const errorURIs: string[] = [];
   log(`Processing ${dfnSources.size} files...`);
   for (let source of dfnSources) {
     try {
-      const terms = parseData(source, errorURIs);
+      const terms = parseData(source);
       updateDataByTerm(terms, dataByTerm);
       updateDataBySpec(terms, dataBySpec);
     } catch (error) {
       logError(`Error while processing ${source.spec}`);
       throw error;
     }
-  }
-
-  if (errorURIs.length) {
-    // ideally never happens. keeping it to prevent database corruption.
-    const msg = `[fixURI]: Failed to resolve base url. (x${errorURIs.length})`;
-    logError(msg, '\n', errorURIs.join('\n'));
-    process.exit(1);
   }
 
   log('Writing processed data files...');
@@ -125,15 +117,10 @@ function updateInputSource() {
 
 /**
  * Parse and format the contents of webref dfn files
- * <https://github.com/tabatkins/bikeshed-data/blob/master/data/anchors/>
  *
- * @param content content of an anchors data file
- * @param errorURIs list of uri where fixUri fails
- *
- * The parsing is based on the file format specified at
- * <https://github.com/tabatkins/bikeshed/blob/0da7328/bikeshed/update/updateCrossRefs.py#L313-L328>
+ * @param source content of an dfns data file
  */
-function parseData(source: DfnSource, errorURIs: string[]) {
+function parseData(source: DfnSource) {
   const dfns = source.dfns;
   const termData = [];
   for (const dfn of dfns) {

--- a/scraper.ts
+++ b/scraper.ts
@@ -46,7 +46,7 @@ export async function main(options: Partial<Options> = {}) {
     return false;
   }
 
-  const { specMap, dfnSources } = await getSpecsData();
+  const { specMap, dfnSources } = await getAllData();
 
   const dataByTerm: DataByTerm = Object.create(null);
   const dataBySpec: DataBySpec = Object.create(null);
@@ -171,8 +171,8 @@ function normalizeTerm(term: string, type: string) {
   return term;
 }
 
-async function getSpecsData() {
-  log(`Getting spec metadata from ${SPECS_JSON}`);
+async function getAllData() {
+  log(`Getting data from ${SPECS_JSON}`);
   const urlFileContent = await readJSON(SPECS_JSON);
   const data: SpecsJSON[] = urlFileContent.results;
 

--- a/scraper.ts
+++ b/scraper.ts
@@ -180,7 +180,7 @@ async function getSpecsData() {
 
   for (const entry of data) {
     specUrls.add(entry.nightly.url);
-    if (entry.release && entry.release.url) specUrls.add(entry.release.url);
+    if (entry.release?.url) specUrls.add(entry.release.url);
     if (entry.dfns) {
       const dfnsData = await readJSON(joinPath(INPUT_DIR_BASE, entry.dfns));
       const dfns: InputDfn[] = dfnsData.dfns;

--- a/scraper.ts
+++ b/scraper.ts
@@ -46,7 +46,7 @@ export async function main(options: Partial<Options> = {}) {
     return false;
   }
 
-  const { specMap, urls, dfnSources } = await getSpecsData();
+  const { specMap, dfnSources } = await getSpecsData();
 
   const dataByTerm: DataByTerm = Object.create(null);
   const dataBySpec: DataBySpec = Object.create(null);
@@ -201,7 +201,7 @@ async function getSpecsData() {
     };
   }
 
-  return { urls, specMap, dfnSources };
+  return { specMap, dfnSources };
 }
 
 async function readJSON(filePath: string) {

--- a/scraper.ts
+++ b/scraper.ts
@@ -195,7 +195,7 @@ async function getAllData() {
     }
 
     specMap[entry.shortname] = {
-      url: entry.nightly.url || (entry.release ? entry.release.url : entry.url),
+      url: entry.nightly.url || entry.release?.url || entry.url,
       title: entry.title,
       shortname: entry.shortname,
     };

--- a/scraper.ts
+++ b/scraper.ts
@@ -1,4 +1,4 @@
-// Reads and parses anchor data files from webref repository and writes:
+// Reads and parses definition data files from webref repository and writes:
 // - xref.json containing parsed and formatted data by term
 // - specs.json having data by spec shortname
 // - specmap.json having spec details

--- a/scraper.ts
+++ b/scraper.ts
@@ -182,7 +182,7 @@ async function getAllData() {
       });
     }
 
-    specMap[entry.shortname.toLowerCase()]
+    specMap[entry.shortname.toLowerCase()] = {
       url: entry.nightly.url || entry.release?.url || entry.url,
       title: entry.title,
       shortname: entry.series.shortname.toLowerCase(),

--- a/scraper.ts
+++ b/scraper.ts
@@ -116,8 +116,8 @@ function mapDefinition(
     term: normalizeTerm(term, normalizedType),
     isExported: dfn.access === 'public',
     type: normalizedType,
-    spec: spec.spec,
-    shortname: spec.shortname,
+    spec: spec.spec.toLowerCase(),
+    shortname: spec.shortname.toLowerCase(),
     status: 'current',
     uri: dfn.href.replace(spec.url, ''), // This is full URL to term here
     normative: !dfn.informative,
@@ -153,6 +153,9 @@ function normalizeTerm(term: string, type: string) {
   if (type === 'method' && !term.endsWith(')')) {
     return term + '()';
   }
+  if (type === "dfn") {
+    return term.toLowerCase();
+  }
   return term;
 }
 
@@ -179,10 +182,10 @@ async function getAllData() {
       });
     }
 
-    specMap[entry.shortname] = {
+    specMap[entry.shortname.toLowerCase()]
       url: entry.nightly.url || entry.release?.url || entry.url,
       title: entry.title,
-      shortname: entry.shortname,
+      shortname: entry.series.shortname.toLowerCase(),
     };
   }
 

--- a/scraper.ts
+++ b/scraper.ts
@@ -201,7 +201,6 @@ async function getSpecsData() {
     };
   }
 
-  const urls = [...specUrls].sort();
   return { urls, specMap, dfnSources };
 }
 


### PR DESCRIPTION
close #69
Compared to the current bikeshed data, this only attemps to load data from editors draft.

Adding support for loading data from TR wouldn't be particularly hard, but would definitely bloat the definition files; since I'm not clear the distinction between "current" and "snapshot" is really used in xref today, I thought I would start with the most useful data set.